### PR TITLE
PLAYGROUND-530 image orientation

### DIFF
--- a/src/PlaygroundCore/Module.php
+++ b/src/PlaygroundCore/Module.php
@@ -234,6 +234,7 @@ class Module implements
                     'playgroundcore_website_service'     => 'PlaygroundCore\Service\Website',
                     'playgroundcore_locale_service'      => 'PlaygroundCore\Service\Locale',
                     'playgroundcore_formgen_service'     => 'PlaygroundCore\Service\Formgen',
+                    'playgroundcore_image_service'       => 'PlaygroundCore\Service\Image',
                 ),
                 'factories' => array(
                     'playgroundcore_module_options' => function ($sm) {

--- a/src/PlaygroundCore/Service/Image.php
+++ b/src/PlaygroundCore/Service/Image.php
@@ -1,0 +1,127 @@
+<?php
+namespace PlaygroundCore\Service;
+
+use ZfcBase\EventManager\EventProvider;
+use Zend\ServiceManager\ServiceManagerAwareInterface;
+use Zend\ServiceManager\ServiceManager;
+
+/**
+ * 
+ * @author AdFab
+ * 
+ * require php_exif for some methods
+ * 
+ * TODO only jpeg is possible for now, it would be nice to allow png, gif, ...
+ *
+ */
+class Image extends EventProvider implements ServiceManagerAwareInterface
+{
+    
+    protected $file;
+    
+    /**
+     * @var resource
+     */
+    protected $image;
+    
+    public function __construct(/*$file*/)
+    {
+        /*if (!file_exists($file)) {
+            throw new \Exception('Not a file: "' . $file . '"', null, null);
+        }
+        $this->file = $file;
+        $this->image = imagecreatefromstring(
+            file_get_contents($file)
+        );*/
+    }
+    
+    /**
+     * @param string $file
+     * @throws \Exception if the file does not exists
+     * @return \PlaygroundCore\Service\Image
+     */
+    public function setImage($file)
+    {
+        if (!file_exists($file)) {
+            throw new \Exception('Not a file: "' . $file . '"', null, null);
+        }
+        $this->file = $file;
+        $this->image = imagecreatefromstring(
+            file_get_contents($file)
+        );
+        return $this;
+    }
+    
+    /**
+     * @return boolean
+     */
+    public function canCorrectOrientation()
+    {
+        return function_exists('exif_read_data');
+    }
+    
+    /**
+     * Correct image orientation (if present in the medadata)
+     * use php_exif
+     * @return \PlaygroundCore\Service\Image
+     */
+    public function correctOrientation()
+    {
+        $exif = exif_read_data($this->file);
+        if(!empty($exif['Orientation'])) {
+            switch($exif['Orientation']) {
+                case 8:
+                    $this->image = imagerotate($this->image,90,0);
+                    break;
+                case 3:
+                    $this->image = imagerotate($this->image,180,0);
+                    break;
+                case 6:
+                    $this->image = imagerotate($this->image,-90,0);
+                    break;
+            }
+        }
+        return $this;
+    }
+    
+    /**
+     * save as jpeg
+     * @param string $path
+     * @return \PlaygroundCore\Service\Image
+     */
+    public function save($path = null)
+    {
+        if (is_null($path)) {
+            $path = $this->file;
+        }
+        imagejpeg($this->image, $path);
+        return $this;
+    }
+
+    /**
+     * @return \Zend\ServiceManager\ServiceManager
+     */
+    public function getServiceManager()
+    {
+        return $this->serviceManager;
+    }
+    
+    /**
+     * output as jpeg
+     */
+    public function __toString()
+    {
+        echo imagejpeg($this->image);
+    }
+
+    /**
+     * @param ServiceManager $serviceManager
+     * @return \PlaygroundCore\Service\Image
+     */
+    public function setServiceManager(ServiceManager $serviceManager)
+    {
+        $this->serviceManager = $serviceManager;
+        return $this;
+    }
+    
+}


### PR DESCRIPTION
Permet de tourner les images dans le bon sens grâce aux metadatas et de les ré enregistrer.
typiquement lorsque elle est prise depuis un appareil mobile.
